### PR TITLE
deleted belongs to admin to avoid admin bug

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -3,7 +3,6 @@ class Member < ApplicationRecord
 
     has_many :meetings, through: :attendances
     has_many :attendances
-    belongs_to :admin
     validates :name, :email, presence: true
     validates_uniqueness_of :email
 


### PR DESCRIPTION
solve "Admin must exist" issue when creating a member